### PR TITLE
The SSLContext shouldn't be configured as default application wide.

### DIFF
--- a/src/main/java/com/indix/tools/SSLTrustCA.java
+++ b/src/main/java/com/indix/tools/SSLTrustCA.java
@@ -67,7 +67,6 @@ public final class SSLTrustCA {
             tmf.init(keyStore);
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, tmf.getTrustManagers(), null);
-            SSLContext.setDefault(sslContext);
             return sslContext;
         } catch (Exception ex) {
             throw new RuntimeException(ex);


### PR DESCRIPTION
A developer wouldn't want these configurations set as default for all HTTP clients.